### PR TITLE
Footer full width also on desktop

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -1,7 +1,6 @@
 .footer-wrapper {
   background: $lighter-grey;
   margin-top: 15px;
-
 }
 
 #footer {

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <div class="container-fluid">
   <div class="row">
-    <div class="col-xs-12 col-md-6 col-lg-6 footer-wrapper">
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 footer-wrapper">
       <div id="footer">
         <div class="footer-links list-fab">
           <%= link_to 'https://www.instagram.com/marbear9000/'  do %>


### PR DESCRIPTION
Full width on mobile and desktop
<img width="1261" alt="footer_desktop" src="https://user-images.githubusercontent.com/43215015/48696671-deecd780-ebe2-11e8-8616-6031b6024557.png">
<img width="324" alt="footer_mobile" src="https://user-images.githubusercontent.com/43215015/48696677-e318f500-ebe2-11e8-96cb-bc6d4586d3d4.png">

